### PR TITLE
Add support for dot-operator 

### DIFF
--- a/LANGREF.md
+++ b/LANGREF.md
@@ -1,4 +1,4 @@
-# TCE language reference
+# TCE v1.1 language reference
 
 ## Introduction
 
@@ -14,6 +14,7 @@ TCEs follow the same structure. They consist of category tier names separated by
 
   - `agf > groente`
   - `agf > groente > komkommer`
+  - `agf > groente > komkommer.`
   - `agf > groente > kom%`
   - `agf > groente | fruit > komkommer`
   - `agf > groente > !tomaat`
@@ -105,6 +106,41 @@ Note that TCEs are considered equal if they match the same categories. E.g. thes
 ["Rucola"]
 ```
 
+### Explicit last tier(s) `.`
+```ruby
+"agf > groente > komkommer."
+
+# Matches
+["AGF", "Groente", "Komkommer"]
+
+# Does not match
+["AGF", "Groente", "Komkommer", "Snack komkommer"]
+```
+
+```ruby
+"agf > groente. > komkommer"
+
+# Matches
+["AGF", "Groente"]
+["AGF", "Groente", "Komkommer"]
+["AGF", "Groente", "Komkommer", "Snack komkommer"]
+
+# Does not match
+["AGF", "Groente", "Tomaat"]
+```
+
+```ruby
+"agf > groente. > komkommer."
+
+# Matches
+["AGF", "Groente"]
+["AGF", "Groente", "Komkommer"]
+
+# Does not match
+["AGF", "Groente", "Tomaat"]
+["AGF", "Groente", "Komkommer", "Snack komkommer"]
+```
+
 ### Combining patterns
 ```ruby
 "groente > seizoensgroente > %"
@@ -141,4 +177,22 @@ Note that TCEs are considered equal if they match the same categories. E.g. thes
 ["Nonfood", "Babyvoeding"]
 ["Nonfood", "Diervoeding"]
 ["Nonfood"]
+```
+
+```ruby
+"voeding. >> %voeding."
+
+# Matches
+["Voeding"]
+["Voeding", "Babyvoeding"]
+["Voeding", "Diervoeding"]
+["Voeding", "Baby", "Babyvoeding"]
+["Voeding", "Dier", "Diervoeding"]
+
+# Does not match
+["Voeding", "AGF"]
+["Voeding", "Babyvoeding", "Newborn"]
+["Voeding", "Diervoeding", "Hond"]
+["Voeding", "Baby", "Babyvoeding", "Newborn"]
+["Voeding", "Dier", "Diervoeding", "Hond"]
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tiered Category Expressions
 
-Work with TCEs in Ruby.
+Work with TCE v1.1 in Ruby.
 
 ## Installation
 

--- a/lib/tiered_category_expressions/expression.rb
+++ b/lib/tiered_category_expressions/expression.rb
@@ -36,6 +36,8 @@ module TieredCategoryExpressions
       raise ParseError, "unexpected input at character #{column}"
     end
 
+    # @param strict [Boolean] If +true+ is given then the object should not match categories with tiers that extend
+    #   beyond those specified by the TCE. This is the case when the TCE ends with ".".
     # @!visibility private
     def initialize(tiers, strict:)
       @tiers = tiers

--- a/lib/tiered_category_expressions/expression.rb
+++ b/lib/tiered_category_expressions/expression.rb
@@ -37,8 +37,9 @@ module TieredCategoryExpressions
     end
 
     # @!visibility private
-    def initialize(tiers)
+    def initialize(tiers, strict:)
       @tiers = tiers
+      @strict = strict
     end
 
     # @!visibility private
@@ -46,14 +47,18 @@ module TieredCategoryExpressions
       "TieredCategoryExpressions::Expression[#{self}]"
     end
 
+    # @param implied_root [Boolean] If +true+ no leading ">" is included.
     # @return [String] String representation of the expression
-    def to_s
-      @tiers.join(" ").sub(/^>(?!>)\s*/, "") # Initial ">" is implied (but ">>" is not)
+    def to_s(implied_root: true)
+      str = @tiers.join(" ")
+      str << "." if @strict
+      str = str.sub(/^>(?!>)\s*/, "") if implied_root # Initial ">" is implied (but ">>" is not)
+      str
     end
 
     # @return [Regexp] Regexp representation of the expression as a string (does not include flags)
     def as_regexp
-      "^#{@tiers.map(&:as_regexp).join}"
+      "^#{@tiers.map(&:as_regexp).join}#{'$' if @strict}"
     end
 
     # @return [String] Regexp representation of the expression
@@ -65,6 +70,7 @@ module TieredCategoryExpressions
     #
     # @param category [Array<String>] Category to match
     # @return [Boolean]
+    #
     def matches?(category)
       to_regexp.match?(Preprocessor.call(category))
     end
@@ -89,14 +95,14 @@ module TieredCategoryExpressions
     # @return [Expression]
     #
     def >(other)
-      self.class.new(@tiers + TieredCategoryExpressions::TCE(other).tiers)
+      TieredCategoryExpressions::TCE(to_s + TieredCategoryExpressions::TCE(other).to_s(implied_root: false))
     end
 
     # Returns an SQL LIKE query that may be used to speed up certain SQL queries.
     #
     # SQL queries that involve matching some input against stored TCE regexps can be slow. Possibly, they can be
     # optimized by applying a much faster LIKE query first, which reduces the number of regexps to apply. The LIKE
-    # query alone still yields false positives, so it must be combined with the corresponding regexp.
+    # query alone can still yield false positives, so it must be combined with the corresponding regexp.
     #
     # For instance:
     #
@@ -109,7 +115,9 @@ module TieredCategoryExpressions
     # Depending on the TCEs in the _mappings_ table.
     #
     def as_sql_like_query
-      @tiers.map(&:as_sql_like_query).join + "%"
+      q = @tiers.map(&:as_sql_like_query).join
+      q += "%" unless @strict || q.end_with?("%")
+      q
     end
 
     protected

--- a/lib/tiered_category_expressions/parser.rb
+++ b/lib/tiered_category_expressions/parser.rb
@@ -19,7 +19,14 @@ module TieredCategoryExpressions
     rule(:name)      { word.repeat(1).as(:name) }
     rule(:namelist)  { (name >> (namesep >> name).repeat).as(:namelist) }
 
-    rule(:tce)       { space? >> (((connector | negator).as(:operator).maybe >> namelist).as(:tier) >> (connector.as(:operator) >> namelist).as(:tier).repeat).as(:expression) }
+    rule(:stop)      { str(".") >> space? }
+
+    rule(:tier1)     { ((connector | negator).as(:operator).maybe >> namelist).as(:tier) }
+    rule(:tier)      { (connector.as(:operator) >> namelist).as(:tier) }
+    rule(:tiers)     { tier.repeat >> (stop >> (tier.repeat(1, 1) >> tiers).as(:tail)).maybe }
+
+    rule(:tce)       { space? >> ((tier1.repeat(1, 1) >> tiers).as(:tiers) >> stop.as(:eoct).maybe).as(:expr) }
+
     root(:tce)
   end
 end

--- a/lib/tiered_category_expressions/tail.rb
+++ b/lib/tiered_category_expressions/tail.rb
@@ -1,0 +1,19 @@
+module TieredCategoryExpressions
+  class Tail
+    def initialize(tiers)
+      @tiers = tiers
+    end
+
+    def to_s
+      ". " + @tiers.join(" ")
+    end
+
+    def as_regexp
+      "($|(#{@tiers.map(&:as_regexp).join}))"
+    end
+
+    def as_sql_like_query
+      "%"
+    end
+  end
+end

--- a/lib/tiered_category_expressions/tiers.rb
+++ b/lib/tiered_category_expressions/tiers.rb
@@ -1,5 +1,18 @@
 module TieredCategoryExpressions
   class Tier < Struct.new(:operator, :namelist)
+    def self.build(operator, names)
+      klass = case operator&.to_s&.tr(" ", "")
+      when ">",  nil then Child
+      when ">!", "!" then IChild
+      when ">>"      then Descendant
+      when ">>!"     then IDescendant
+      else raise "no such operator #{operator.inspect}"
+      end
+
+      namelist = Namelist.new([names].flatten)
+      klass.new(namelist)
+    end
+
     def to_s
       "#{operator} #{namelist}"
     end
@@ -32,7 +45,7 @@ module TieredCategoryExpressions
       end
 
       def as_regexp
-        "(?!#{namelist.as_regexp}>).+>"
+        "(?!#{namelist.as_regexp}>)[a-z0-9]+>"
       end
 
       def as_sql_like_query
@@ -46,7 +59,7 @@ module TieredCategoryExpressions
       end
 
       def as_regexp
-        "(.+>)*#{namelist.as_regexp}>"
+        "([a-z0-9]+>)*#{namelist.as_regexp}>"
       end
 
       def as_sql_like_query
@@ -60,7 +73,7 @@ module TieredCategoryExpressions
       end
 
       def as_regexp
-        "(?!(.+>)*#{namelist.as_regexp}>).+>"
+        "(?!([a-z0-9]+>)*#{namelist.as_regexp}>)([a-z0-9]+>)+"
       end
 
       def as_sql_like_query

--- a/lib/tiered_category_expressions/transformer.rb
+++ b/lib/tiered_category_expressions/transformer.rb
@@ -2,25 +2,14 @@ require "parslet"
 require "tiered_category_expressions/name"
 require "tiered_category_expressions/namelist"
 require "tiered_category_expressions/tiers"
+require "tiered_category_expressions/tail"
 require "tiered_category_expressions/expression"
 
 module TieredCategoryExpressions
   class Transformer < Parslet::Transform
-    rule(:name => simple(:name)) { Name.new(name.to_s) }
-
-    rule(:tier => subtree(:tier)) do
-      klass = case tier[:operator]&.to_s&.tr(" ", "")
-      when ">",  nil then Tier::Child
-      when ">!", "!" then Tier::IChild
-      when ">>"      then Tier::Descendant
-      when ">>!"     then Tier::IDescendant
-      else raise "no such operator #{tier[:operator].inspect}"
-      end
-
-      namelist = Namelist.new([tier[:namelist]].flatten)
-      klass.new(namelist)
-    end
-
-    rule(:expression => subtree(:tiers)) { Expression.new([tiers].flatten) }
+    rule(:name => simple(:name))    { Name.new(name.to_s) }
+    rule(:tier => subtree(:tier))   { Tier.build(tier[:operator], tier[:namelist]) }
+    rule(:tail => sequence(:tiers)) { Tail.new(tiers) }
+    rule(:expr => subtree(:expr))   { Expression.new(expr[:tiers], strict: expr.has_key?(:eoct)) }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,7 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "tiered_category_expressions"
+require_relative "./support/sql_helper"
+
+RSpec.configure do |config|
+  config.include SQLHelper
+end

--- a/spec/support/sql_helper.rb
+++ b/spec/support/sql_helper.rb
@@ -1,0 +1,13 @@
+module SQLHelper
+  def sql_like?(like_query, string_to_match)
+    sql_like_to_regexp(like_query).match? string_to_match
+  end
+
+  def sql_like_to_regexp(like_query)
+    pattern = Regexp.escape like_query
+    pattern = pattern.gsub "%", ".*"
+    pattern = pattern.gsub "\\?", "."
+    pattern = "\\A#{pattern}\\z"
+    Regexp.new pattern
+  end
+end

--- a/spec/tiered_category_expressions_spec.rb
+++ b/spec/tiered_category_expressions_spec.rb
@@ -32,209 +32,257 @@ describe TieredCategoryExpressions do
         end
       end
 
-      context "given an invalid string" do
-        it "raises a ParseError" do
-          expect { TieredCategoryExpressions::Expression.parse("???") }.to raise_error \
-            TieredCategoryExpressions::ParseError
+      [
+        ".",
+        ".foo",
+        "foo..",
+        "foo!",
+        "!!foo",
+        "foo?",
+        "foo >",
+        "foo >>",
+        "foo > .",
+        "foo > !",
+        "foo >> !",
+        "foo >>> bar",
+        "foo || bar",
+        "foo < bar",
+        "(foo)"
+      ].each do |str|
+        context "given #{str.inspect}" do
+          it "raises a ParseError" do
+            expect { TieredCategoryExpressions::Expression.parse(str) }.to raise_error \
+              TieredCategoryExpressions::ParseError
+          end
         end
       end
     end
 
+    tce_examples = [
+      # [TCE, category, should_match?]
+      ["foo", %w[foo],     true],
+      ["foo", %w[FOO],     true],
+      ["foo", %w[foo bar], true],
+      ["foo", %w[bar],     false],
+      ["foo", %w[fooo],    false],
+      ["foo", [],          false],
+
+      ["foo > bar", %w[foo bar],     true],
+      ["foo > bar", %w[foo BAR],     true],
+      ["foo > bar", %w[foo bar baz], true],
+      ["foo > bar", %w[foo],         false],
+      ["foo > bar", %w[foo baz],     false],
+      ["foo > bar", %w[foo barr],    false],
+      ["foo > bar", %w[fooo bar],    false],
+
+      ["foo > bar > baz", %w[foo bar baz],     true],
+      ["foo > bar > baz", %w[foo bar baz qux], true],
+      ["foo > bar > baz", %w[foo bar],         false],
+      ["foo > bar > baz", %w[foo bar qux],     false],
+      ["foo > bar > baz", %w[foo qux baz],     false],
+
+      ["b%",   %w[bar],   true],
+      ["b%",   %w[baz],   true],
+      ["%o",   %w[foo],   true],
+      ["%o",   %w[boo],   true],
+      ["f%o",  %w[foo],   true],
+      ["f%o",  %w[foooo], true],
+      ["%",    %w[foo],   true],
+      ["foo%", %w[foo],   true],
+      ["%",    %w[],      false],
+      ["f%",   %w[bar],   false],
+      ["f%",   %w[bff],   false],
+
+      ["f%",   %w[foo bar],     true],
+      ["%oo",  %w[foo bar],     true],
+      ["f%r",  %w[foo bar],     false],
+      ["%ar",  %w[foo bar],     false],
+      ["ba%",  %w[foo bar],     false],
+      ["f%z",  %w[foo bar baz], false],
+
+      ["foo > %", %w[foo bar],     true],
+      ["foo > %", %w[foo bar baz], true],
+      ["foo > %", %w[foo],         false],
+
+      ["f% > % > %z", %w[foo bar baz], true],
+      ["f% > % > %z", %w[foo baz bar], false],
+      ["f% > % > %z", %w[bar foo baz], false],
+
+      ["foo | bar", %w[foo], true],
+      ["foo | bar", %w[bar], true],
+      ["foo | bar", %w[baz], false],
+      ["foo | bar", [],      false],
+
+      ["foo | bar | qux", %w[foo], true],
+      ["foo | bar | qux", %w[bar], true],
+      ["foo | bar | qux", %w[qux], true],
+      ["foo | bar | qux", %w[baz], false],
+      ["foo | bar | qux", [],      false],
+
+      ["!foo", %w[foo],     false],
+      ["!foo", %w[foo bar], false],
+      ["!foo", %w[fooo],    true],
+      ["!foo", %w[fo],      true],
+      ["!foo", %w[bar baz], true],
+
+      ["!%", %w[foo],     false],
+      ["!%", %w[foo bar], false],
+
+      ["foo > !bar", %w[foo bar],     false],
+      ["foo > !bar", %w[foo baz],     true],
+      ["foo > !bar", %w[foo baz bar], true],
+
+      ["!foo > !bar", %w[foo bar],     false],
+      ["!foo > !bar", %w[foo baz],     false],
+      ["!foo > !bar", %w[baz bar],     false],
+      ["!foo > !bar", %w[baz foo bar], true],
+      ["!foo > !%",   %w[bar baz],     false],
+
+      [">> baz", %w[baz],         true],
+      [">> baz", %w[foo baz],     true],
+      [">> baz", %w[foo bar baz], true],
+      [">> baz", %w[foo bar],     false],
+      [">> baz", %w[bazz],        false],
+
+      ["foo >> baz", %w[foo baz],         true],
+      ["foo >> baz", %w[foo bar baz],     true],
+      ["foo >> baz", %w[foo bar qux baz], true],
+      ["foo >> baz", %w[foo],             false],
+      ["foo >> baz", %w[baz],             false],
+      ["foo >> baz", %w[foo bar],         false],
+      ["foo >> baz", %w[bar baz],         false],
+
+      ["foo", %w[foo],         true],
+      ["foo", %w[foo bar],     true],
+      ["foo", %w[foo bar baz], true],
+      ["foo", %w[bar foo],     false],
+
+      [">> !baz", %w[baz],         false],
+      [">> !baz", %w[foo baz],     false],
+      [">> !baz", %w[foo bar baz], false],
+
+      [">> foo > !baz", %w[baz foo bar],         true],
+      [">> foo > !baz", %w[baz foo baz],         false],
+      [">> foo > !baz", %w[baz bar foo baz],     false],
+      [">> foo > !baz", %w[baz bar qux foo baz], false],
+
+      [">> !foo > bar", %w[baz bar],     true],
+      [">> !foo > bar", %w[baz qux bar], true],
+      [">> !foo > bar", %w[bar],         false],
+      [">> !foo > bar", %w[foo],         false],
+      [">> !foo > bar", %w[foo bar],     false],
+      [">> !foo > bar", %w[baz foo bar], false],
+      [">> !foo > bar", %w[baz qux],     false],
+
+      ["foo > b% > !baz > qux | quux >> ! foo | bar", %w[foo bar xxx quux yyy zzz], true],
+      ["foo > b% > !baz > qux | quux >> ! foo | bar", %w[foo bar xxx quux yyy foo], false],
+      ["foo > b% > !baz > qux | quux >> ! foo | bar", %w[foo bar xxx quux bar yyy], false],
+
+      ["foo", ["FOO"], true],
+      ["123", ["123"], true],
+
+      ["foo bar", ["foobar"],   true],
+      ["foobar",  ["foo bar"],  true],
+      ["foo bar", ["foo bar"],  true],
+
+      ["foobar", ["foo_bar"],  true],
+      ["foobar", ["foo-bar"],  true],
+      ["foobar", ["foo+bar"],  true],
+      ["foobar", ["foo&bar"],  true],
+      ["foobar", ["foo,bar"],  true],
+      ["foobar", ["foo;bar"],  true],
+      ["foobar", ["foo:bar"],  true],
+      ["foobar", ["foo/bar"],  true],
+      ["foobar", ["foo\\bar"], true],
+      ["foobar", ["foo|bar"],  true],
+      ["foobar", ["foo=bar"],  true],
+
+      ["foo", %w['foo'],       true],
+      ["foo", %w["foo"],       true],
+      ["foo", %w[<{[(foo)]}>], true],
+      ["foo", %w[*foo*],       true],
+      ["foo", %w[%foo%],       true],
+      ["foo", %w[`foo`],       true],
+      ["foo", %w[foo?],        true],
+      ["foo", %w[foo!],        true],
+
+      ["Ħöø ÇåŖ ĢŬŬĐ", ["ĤŐŌ ČĄr Ğûüď"], true],
+
+      ["foo.", %w[foo],           true],
+      ["foo.", %w[foo bar],       false],
+
+      ["foo | bar.", %w[foo],     true],
+      ["foo | bar.", %w[bar],     true],
+      ["foo | bar.", %w[foo bar], false],
+      ["foo | bar.", %w[bar foo], false],
+
+      ["foo > bar.", %w[foo bar],     true],
+      ["foo > bar.", %w[foo bar baz], false],
+
+      ["foo. > bar", %w[foo],           true],
+      ["foo. > bar", %w[foo bar],       true],
+      ["foo. > bar", %w[foo bar baz],   true],
+      ["foo. > bar", %w[foo baz],       false],
+
+      ["foo. > bar.", %w[foo],         true],
+      ["foo. > bar.", %w[foo bar],     true],
+      ["foo. > bar.", %w[foo baz],     false],
+      ["foo. > bar.", %w[foo bar baz], false],
+
+      ["foo. > bar. > baz", %w[foo],             true],
+      ["foo. > bar. > baz", %w[foo bar],         true],
+      ["foo. > bar. > baz", %w[foo bar baz],     true],
+      ["foo. > bar. > baz", %w[foo bar baz qux], true],
+      ["foo. > bar. > baz", %w[foo baz],         false],
+
+      # Examples from LANGREF.md:
+
+      ["agf > groente > komkommer", ["AGF", "Groente", "Komkommer"], true],
+      ["agf > groente > komkommer", ["AGF", "Groente", "Komkommer", "Snack komkommer"], true],
+      ["agf > groente > komkommer", ["AGF", "Groente"], false],
+      ["agf > groente > komkommer", ["AGF", "Groente", "Tomaat"], false],
+      ["agf > groente > komkommer", ["Groente & fruit", "Groente", "Komkommer"], false],
+
+      ["agf >> komkommer", ["AGF", "Komkommer"], true],
+      ["agf >> komkommer", ["AGF", "Komkommer", "Snack komkommer"], true],
+      ["agf >> komkommer", ["AGF", "Groente", "Komkommer", "Snack komkommer"], true],
+      ["agf >> komkommer", ["AGF"], false],
+      ["agf >> komkommer", ["AGF", "Snack komkommer"], false],
+      ["agf >> komkommer", ["AGF", "Groente", "Snack komkommer"], false],
+
+      ["groente% > %komkommer", ["Groente", "Komkommer"], true],
+      ["groente% > %komkommer", ["Groente & fruit", "Snack komkommer"], true],
+
+      ["!komkommer", ["Komkommer"], false],
+
+      ["veldsla | ijsbergsla | rucola", ["Veldsla"], true],
+      ["veldsla | ijsbergsla | rucola", ["IJsbergsla"], true],
+      ["veldsla | ijsbergsla | rucola", ["Rucola"], true],
+
+
+      ["groente > seizoensgroente > %", ["Groente", "Seizoensgroente", "Pastinaak"], true],
+      ["groente > seizoensgroente > %", ["Groente", "Seizoensgroente", "Vers", "Pastinaak"], true],
+      ["groente > seizoensgroente > %", ["Groente", "Seizoensgroente"], false],
+
+      [">> !komkommer%", ["Komkommer"], false],
+      [">> !komkommer%", ["Komkommer & fruit"], false],
+      [">> !komkommer%", ["AGF", "Komkommer"], false],
+      [">> !komkommer%", ["AGF", "Komkommer & fruit"], false],
+      [">> !komkommer%", ["AGF", "Groente", "Komkommer"], false],
+
+      ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood", "Baby", "Flessen"], true],
+      ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood", "Huisdier", "Aanlijnriemen"], true],
+      ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood", "Baby", "Babyvoeding"], false],
+      ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood", "Huisdier", "Diervoeding"], false],
+      ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood", "Babyvoeding"], false],
+      ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood", "Diervoeding"], false],
+      ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood"], false]
+    ]
+
     describe "#matches?" do
-      [ # [TCE, category, should_match?]
-        ["foo", %w[foo],     true],
-        ["foo", %w[FOO],     true],
-        ["foo", %w[foo bar], true],
-        ["foo", %w[bar],     false],
-        ["foo", %w[fooo],    false],
-        ["foo", [],          false],
-
-        ["foo > bar", %w[foo bar],     true],
-        ["foo > bar", %w[foo BAR],     true],
-        ["foo > bar", %w[foo bar baz], true],
-        ["foo > bar", %w[foo],         false],
-        ["foo > bar", %w[foo baz],     false],
-        ["foo > bar", %w[foo barr],    false],
-        ["foo > bar", %w[fooo bar],    false],
-
-        ["foo > bar > baz", %w[foo bar baz],     true],
-        ["foo > bar > baz", %w[foo bar baz qux], true],
-        ["foo > bar > baz", %w[foo bar],         false],
-        ["foo > bar > baz", %w[foo bar qux],     false],
-        ["foo > bar > baz", %w[foo qux baz],     false],
-
-        ["b%",   %w[bar],   true],
-        ["b%",   %w[baz],   true],
-        ["%o",   %w[foo],   true],
-        ["%o",   %w[boo],   true],
-        ["f%o",  %w[foo],   true],
-        ["f%o",  %w[foooo], true],
-        ["%",    %w[foo],   true],
-        ["foo%", %w[foo],   true],
-        ["%",    %w[],      false],
-        ["f%",   %w[bar],   false],
-        ["f%",   %w[bff],   false],
-
-        ["f%",   %w[foo bar],     true],
-        ["%oo",  %w[foo bar],     true],
-        ["f%r",  %w[foo bar],     false],
-        ["%ar",  %w[foo bar],     false],
-        ["ba%",  %w[foo bar],     false],
-        ["f%z",  %w[foo bar baz], false],
-
-        ["foo > %", %w[foo bar],     true],
-        ["foo > %", %w[foo bar baz], true],
-        ["foo > %", %w[foo],         false],
-
-        ["f% > % > %z", %w[foo bar baz], true],
-        ["f% > % > %z", %w[foo baz bar], false],
-        ["f% > % > %z", %w[bar foo baz], false],
-
-        ["foo | bar", %w[foo], true],
-        ["foo | bar", %w[bar], true],
-        ["foo | bar", %w[baz], false],
-        ["foo | bar", [],      false],
-
-        ["foo | bar | qux", %w[foo], true],
-        ["foo | bar | qux", %w[bar], true],
-        ["foo | bar | qux", %w[qux], true],
-        ["foo | bar | qux", %w[baz], false],
-        ["foo | bar | qux", [],      false],
-
-        ["!foo", %w[foo],     false],
-        ["!foo", %w[foo bar], false],
-        ["!foo", %w[fooo],    true],
-        ["!foo", %w[fo],      true],
-        ["!foo", %w[bar baz], true],
-
-        ["!%", %w[foo],     false],
-        ["!%", %w[foo bar], false],
-
-        ["foo > !bar", %w[foo bar],     false],
-        ["foo > !bar", %w[foo baz],     true],
-        ["foo > !bar", %w[foo baz bar], true],
-
-        ["!foo > !bar", %w[foo bar],     false],
-        ["!foo > !bar", %w[foo baz],     false],
-        ["!foo > !bar", %w[baz bar],     false],
-        ["!foo > !bar", %w[baz foo bar], true],
-        ["!foo > !%",   %w[bar baz],     false],
-
-        [">> baz", %w[baz],         true],
-        [">> baz", %w[foo baz],     true],
-        [">> baz", %w[foo bar baz], true],
-        [">> baz", %w[foo bar],     false],
-        [">> baz", %w[bazz],        false],
-
-        ["foo >> baz", %w[foo baz],         true],
-        ["foo >> baz", %w[foo bar baz],     true],
-        ["foo >> baz", %w[foo bar qux baz], true],
-        ["foo >> baz", %w[foo],             false],
-        ["foo >> baz", %w[baz],             false],
-        ["foo >> baz", %w[foo bar],         false],
-        ["foo >> baz", %w[bar baz],         false],
-
-        ["foo", %w[foo],         true],
-        ["foo", %w[foo bar],     true],
-        ["foo", %w[foo bar baz], true],
-        ["foo", %w[bar foo],     false],
-
-        [">> !baz", %w[baz],         false],
-        [">> !baz", %w[foo baz],     false],
-        [">> !baz", %w[foo bar baz], false],
-
-        [">> foo > !baz", %w[baz foo bar],         true],
-        [">> foo > !baz", %w[baz foo baz],         false],
-        [">> foo > !baz", %w[baz bar foo baz],     false],
-        [">> foo > !baz", %w[baz bar qux foo baz], false],
-
-        [">> !foo > bar", %w[baz bar],     true],
-        [">> !foo > bar", %w[baz qux bar], true],
-        [">> !foo > bar", %w[bar],         false],
-        [">> !foo > bar", %w[foo],         false],
-        [">> !foo > bar", %w[foo bar],     false],
-        [">> !foo > bar", %w[baz foo bar], false],
-        [">> !foo > bar", %w[baz qux],     false],
-
-        ["foo > b% > !baz > qux | quux >> ! foo | bar", %w[foo bar xxx quux yyy zzz], true],
-        ["foo > b% > !baz > qux | quux >> ! foo | bar", %w[foo bar xxx quux yyy foo], false],
-        ["foo > b% > !baz > qux | quux >> ! foo | bar", %w[foo bar xxx quux bar yyy], false],
-
-        ["foo", ["FOO"], true],
-        ["123", ["123"], true],
-
-        ["foo bar", ["foobar"],   true],
-        ["foobar",  ["foo bar"],  true],
-        ["foo bar", ["foo bar"],  true],
-
-        ["foobar", ["foo_bar"],  true],
-        ["foobar", ["foo-bar"],  true],
-        ["foobar", ["foo+bar"],  true],
-        ["foobar", ["foo&bar"],  true],
-        ["foobar", ["foo,bar"],  true],
-        ["foobar", ["foo;bar"],  true],
-        ["foobar", ["foo:bar"],  true],
-        ["foobar", ["foo/bar"],  true],
-        ["foobar", ["foo\\bar"], true],
-        ["foobar", ["foo|bar"],  true],
-        ["foobar", ["foo=bar"],  true],
-
-        ["foo", %w['foo'],       true],
-        ["foo", %w["foo"],       true],
-        ["foo", %w[<{[(foo)]}>], true],
-        ["foo", %w[*foo*],       true],
-        ["foo", %w[%foo%],       true],
-        ["foo", %w[`foo`],       true],
-        ["foo", %w[foo?],        true],
-        ["foo", %w[foo!],        true],
-
-        ["Ħöø ÇåŖ ĢŬŬĐ", ["ĤŐŌ ČĄr Ğûüď"], true],
-
-        # Examples from LANGREF.md:
-
-        ["agf > groente > komkommer", ["AGF", "Groente", "Komkommer"], true],
-        ["agf > groente > komkommer", ["AGF", "Groente", "Komkommer", "Snack komkommer"], true],
-        ["agf > groente > komkommer", ["AGF", "Groente"], false],
-        ["agf > groente > komkommer", ["AGF", "Groente", "Tomaat"], false],
-        ["agf > groente > komkommer", ["Groente & fruit", "Groente", "Komkommer"], false],
-
-        ["agf >> komkommer", ["AGF", "Komkommer"], true],
-        ["agf >> komkommer", ["AGF", "Komkommer", "Snack komkommer"], true],
-        ["agf >> komkommer", ["AGF", "Groente", "Komkommer", "Snack komkommer"], true],
-        ["agf >> komkommer", ["AGF"], false],
-        ["agf >> komkommer", ["AGF", "Snack komkommer"], false],
-        ["agf >> komkommer", ["AGF", "Groente", "Snack komkommer"], false],
-
-        ["groente% > %komkommer", ["Groente", "Komkommer"], true],
-        ["groente% > %komkommer", ["Groente & fruit", "Snack komkommer"], true],
-
-        ["!komkommer", ["Komkommer"], false],
-
-        ["veldsla | ijsbergsla | rucola", ["Veldsla"], true],
-        ["veldsla | ijsbergsla | rucola", ["IJsbergsla"], true],
-        ["veldsla | ijsbergsla | rucola", ["Rucola"], true],
-
-
-        ["groente > seizoensgroente > %", ["Groente", "Seizoensgroente", "Pastinaak"], true],
-        ["groente > seizoensgroente > %", ["Groente", "Seizoensgroente", "Vers", "Pastinaak"], true],
-        ["groente > seizoensgroente > %", ["Groente", "Seizoensgroente"], false],
-
-        [">> !komkommer%", ["Komkommer"], false],
-        [">> !komkommer%", ["Komkommer & fruit"], false],
-        [">> !komkommer%", ["AGF", "Komkommer"], false],
-        [">> !komkommer%", ["AGF", "Komkommer & fruit"], false],
-        [">> !komkommer%", ["AGF", "Groente", "Komkommer"], false],
-
-        ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood", "Baby", "Flessen"], true],
-        ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood", "Huisdier", "Aanlijnriemen"], true],
-        ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood", "Baby", "Babyvoeding"], false],
-        ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood", "Huisdier", "Diervoeding"], false],
-        ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood", "Babyvoeding"], false],
-        ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood", "Diervoeding"], false],
-        ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood"], false]
-      ].each do |tce, string, expected|
-        it "is #{expected.inspect} when #{TCE(tce).inspect} is matched with #{string.inspect}" do
-          expect(TCE(tce).matches?(string)).to be expected
+      tce_examples.each do |tce, category, expected|
+        it "is #{expected.inspect} when #{TCE(tce).inspect} is matched with #{category.inspect}" do
+          expect(TCE(tce).matches?(category)).to be expected
         end
       end
     end
@@ -259,17 +307,29 @@ describe TieredCategoryExpressions do
         [">> foo | bar",      "%>%"],
         [">> !foo",           "%>%"],
         [">> !fo%",           "%>%"],
-        [">> !foo | bar",     "%>%"]
+        [">> !foo | bar",     "%>%"],
+        ["foo.",              "foo>"],
+        ["foo > bar.",        "foo>bar>"],
+        ["foo. > bar",        "foo>%"],
+        ["foo > bar. > baz",  "foo>bar>%"]
       ].each do |tce, expected|
         it "returns #{expected.inspect} for #{TCE(tce).inspect}" do
           expect(TCE(tce).as_sql_like_query).to eq expected
+        end
+      end
+
+      # Assert absence of false negatives (false positives are ok):
+      tce_examples.select { |_, _, e| e }.each do |tce, category|
+        preprocessed = TieredCategoryExpressions::Preprocessor.call(category)
+        it "matches #{preprocessed.inspect} for #{TCE(tce).inspect}" do
+          expect(sql_like?(TCE(tce).as_sql_like_query, preprocessed)).to be true
         end
       end
     end
 
     describe "#>" do
       it "concatenates strings and expressions" do
-        expect(TCE("noot") > ">> foobar|quux" > TCE("!mies")).to eq TCE("noot >> foobar|quux > !mies")
+        expect(TCE("noot.") > ">> foobar|quux" > TCE("!mies")).to eq TCE("noot. >> foobar|quux > !mies")
       end
     end
 

--- a/spec/tiered_category_expressions_spec.rb
+++ b/spec/tiered_category_expressions_spec.rb
@@ -259,6 +259,18 @@ describe TieredCategoryExpressions do
       ["veldsla | ijsbergsla | rucola", ["IJsbergsla"], true],
       ["veldsla | ijsbergsla | rucola", ["Rucola"], true],
 
+      ["agf > groente > komkommer.", ["AGF", "Groente", "Komkommer"], true],
+      ["agf > groente > komkommer.", ["AGF", "Groente", "Komkommer", "Snack komkommer"], false],
+
+      ["agf > groente. > komkommer", ["AGF", "Groente"], true],
+      ["agf > groente. > komkommer", ["AGF", "Groente", "Komkommer"], true],
+      ["agf > groente. > komkommer", ["AGF", "Groente", "Komkommer", "Snack komkommer"], true],
+      ["agf > groente. > komkommer", ["AGF", "Groente", "Tomaat"], false],
+
+      ["agf > groente. > komkommer.", ["AGF", "Groente"], true],
+      ["agf > groente. > komkommer.", ["AGF", "Groente", "Komkommer"], true],
+      ["agf > groente. > komkommer.", ["AGF", "Groente", "Tomaat"], false],
+      ["agf > groente. > komkommer.", ["AGF", "Groente", "Komkommer", "Snack komkommer"], false],
 
       ["groente > seizoensgroente > %", ["Groente", "Seizoensgroente", "Pastinaak"], true],
       ["groente > seizoensgroente > %", ["Groente", "Seizoensgroente", "Vers", "Pastinaak"], true],
@@ -276,7 +288,18 @@ describe TieredCategoryExpressions do
       ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood", "Huisdier", "Diervoeding"], false],
       ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood", "Babyvoeding"], false],
       ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood", "Diervoeding"], false],
-      ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood"], false]
+      ["nonfood >> ! babyvoeding | diervoeding", ["Nonfood"], false],
+
+      ["voeding. >> %voeding.", ["Voeding"], true],
+      ["voeding. >> %voeding.", ["Voeding", "Babyvoeding"], true],
+      ["voeding. >> %voeding.", ["Voeding", "Diervoeding"], true],
+      ["voeding. >> %voeding.", ["Voeding", "Baby", "Babyvoeding"], true],
+      ["voeding. >> %voeding.", ["Voeding", "Dier", "Diervoeding"], true],
+      ["voeding. >> %voeding.", ["Voeding", "AGF"], false],
+      ["voeding. >> %voeding.", ["Voeding", "Babyvoeding", "Newborn"], false],
+      ["voeding. >> %voeding.", ["Voeding", "Diervoeding", "Hond"], false],
+      ["voeding. >> %voeding.", ["Voeding", "Baby", "Babyvoeding", "Newborn"], false],
+      ["voeding. >> %voeding.", ["Voeding", "Dier", "Diervoeding", "Hond"], false]
     ]
 
     describe "#matches?" do


### PR DESCRIPTION
Implements #2.

- Add support for dot-operator
  - optional end-of-category: `foo. > bar` matches `%w[foo]`, `%w[foo bar]`, `%w[foo bar baz]`, etc.
  - strict end-of-category: `foo > bar.` matches only `%w[foo bar]`, not `%w[foo bar baz]`, etc.
- Add matching-assertions to specs for `#as_sql_like_query` strings (because it's not so non-trivial anymore)
- Introduce v1.1 of TCE language (minor version bump for backwards compatible change, as all V1.0 expressions are still valid)